### PR TITLE
control whether completions or snippets go first

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ For Helix on ~/.config/helix/languages.toml
 ```toml
 # introudce new language server
 # - set max completion results len to 20
-# - write logs to /tmp/completion.log
-[language-server]
-scls = { command = "simple-completion-language-server", config = { "max_completion_items" = 20 }, environment = { "RUST_LOG" = "debug,simple-completion-langauge-server=debug",  "LOG_FILE" = "/tmp/completion.log" } }
+# - completions will return before snippets by default
+[language-server.scls]
+command = "simple-completion-language-server"
+config = { max_completion_items = 20, snippets_first = false }
+
+# write logs to /tmp/completion.log
+[language-server.scls.environment]
+RUST_LOG = "debug,simple-completion-langauge-server=debug"
+LOG_FILE = "/tmp/completion.log"
 
 # introduce new language to enable completion
 # :set-language stub


### PR DESCRIPTION
Add a (boolean) setting `snippets_first` that controls whether completions or snippets get returned first by the LSP.

This change allows for completions to look like
![image](https://github.com/estin/simple-completion-language-server/assets/567092/b7fce624-221c-4f9f-808e-896f391bd831)

which is nice because the default completion is no longer context-dependent (that is, it does not depend on the file I am editing).
