### PR TITLE
Add description field in example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Snippets format
 prefix = "ld"
 scope = [ "python" ]
 body = 'log.debug("$1")'
+description = "log at debug level"
 ```
 
 ### Use external snippets collections from git repos


### PR DESCRIPTION
A simple PR to show the use of the `description` field in the example snippet in the README. Finding the right name (`description`) took me a minute when I had to google, but now it would be directly in the readme :) .