### PR TITLE
Fix completion range for multibyte characters (e.g. Cyrillic)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ impl BackendState {
         }
         .map(|word| {
             let line = params.text_document_position.position.line;
-            let start = params.text_document_position.position.character - prefix.len() as u32;
+            let start = params.text_document_position.position.character - prefix.chars().count() as u32;
             let replace_end = params.text_document_position.position.character;
             let range = Range {
                 start: Position {
@@ -639,7 +639,7 @@ impl BackendState {
             })
             .map(move |s| {
                 let line = params.text_document_position.position.line;
-                let start = params.text_document_position.position.character - prefix.len() as u32;
+                let start = params.text_document_position.position.character - prefix.chars().count() as u32;
                 let replace_end = params.text_document_position.position.character;
                 let range = Range {
                     start: Position {
@@ -784,7 +784,7 @@ impl BackendState {
                     s
                 );
                 let line = params.text_document_position.position.line;
-                let start = params.text_document_position.position.character - part.len() as u32;
+                let start = params.text_document_position.position.character - part.chars().count() as u32;
                 let replace_end = params.text_document_position.position.character;
                 let range = Range {
                     start: Position {
@@ -1011,7 +1011,7 @@ impl BackendState {
                 }
                 let line = params.text_document_position.position.line;
                 let start =
-                    params.text_document_position.position.character - word_prefix.len() as u32;
+                    params.text_document_position.position.character - word_prefix.chars().count() as u32;
                 let replace_end = params.text_document_position.position.character;
                 let range = Range {
                     start: Position {


### PR DESCRIPTION
Fix completion range for multibyte characters (e.g. Cyrillic)

### Problem

When completing a word that starts with multibyte characters (e.g. Cyrillic), selecting a completion item inserts the suggested word after the typed prefix instead of replacing it. For example, typing `При` and selecting `Привіт` results in `ПриПривіт`.

### Root cause

In several places, the start position of the replacement range was calculated using `prefix.len()`, which returns the byte length in UTF-8. For Cyrillic characters (2 bytes each), this value is twice the actual character count, making the range start point too far to the left.

The LSP position encoding is declared as UTF-32 (one unit per Unicode codepoint), so the correct value is `prefix.chars().count()`.
### Fix

Replaced `.len() as u32` with `.chars().count() as u32` in all affected places: words, snippets, unicode_input, and citations.